### PR TITLE
Add forked worker for multiple hooks handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@ An example Ruby program that traps the USR1 signal and read to a named pipe, to 
 Idea
 ----
 
-A program, let's call it _main_, emits the USR1 signal, creates a named pipe (*hook_pipe*) then pauses.
-Another program traps that USR1 signal, performs some task, and write the result to the *hook_pipe*.
-The main program reads the result from the *hook_pipe* and resumes.
+A program, let's call it _main_, is called from another which provides a _worker_ to perform hook that the main program requests.
 
 Usage
 -----
@@ -86,16 +84,29 @@ ruby worker_on_demand.rb # multiple hook requests are handled by the worker
 
 ### Named pipes and fork
 
-...
+The first example has two limitations:
+- only one hook request can be handled by the worker
+- the main program and the worker must agree on two named pipes to communicate
 
+To be able to handle any number of hook requests, the worker must be able to loop while the main program is running. Of course, it should exit once the main program has exited.
+
+In order to do so, let's introduce the `worker_provider` program. It will start a looping worker, then start the main program, and make sure the worker exits when the main program does. It will also provide both named pipes to both the worker and the main program.
+
+```bash
+cd lib/02_named_pipes_and_fork
+
+# start the worker provider program
+ruby worker_provider.rb # will start a worker and a main program with several hooks to perform
+```
 
 References
 ----------
 
 - [Using Named Pipes in Ruby for Inter-process Communication][dix]
+- [Ruby 2.2.0 documentation: Process][doc]
 - [Forking and IPC in Ruby, Part II][fk]
-
 
   [dix]: http://www.pauldix.net/2009/07/using-named-pipes-in-ruby-for-interprocess-communication.html
   [fk]: http://www.sitepoint.com/forking-ipc-ruby-part-ii
   [signals]: https://github.com/gonzalo-bulnes/inter_process_communication_demo/blob/add-signal-handling-to-handle-multiple-hooks/lib/02_signals/on_demand_worker.rb#L48-L56
+  [doc]: http://ruby-doc.org/core-2.2.0/Process.html

--- a/lib/03_named_pipes_and_fork/main.rb
+++ b/lib/03_named_pipes_and_fork/main.rb
@@ -2,52 +2,65 @@ require 'multi_json'
 
 puts 'Main program.'
 
-worker_pid = ARGV[0]
-puts "There is an available worker with PID #{worker_pid}."
+def main_to_worker
+  ARGV[0]
+end
 
-message = [
-            "I'm peeping at you!",
-            {
-              subject: 'Guess what...',
-              to: 'Bob',
-              from: 'Eve',
-              cc: 'Alice',
-            }
-          ]
+def worker_to_main
+  ARGV[1]
+end
 
-json_message = MultiJson.dump(message)
-puts "\nHere is a message to be sent:\n" + json_message + "\n"
+puts "There is an available worker reading at #{main_to_worker} and writing at #{worker_to_main}."
+
+def delegate_hook_to_worker
+  message = [
+              "I'm peeping at you!",
+              {
+                subject: 'Guess what...',
+                to: 'Bob',
+                from: 'Eve',
+                cc: 'Alice',
+              }
+            ]
+
+  json_message = MultiJson.dump(message)
+  puts "\nHere is a message to be sent:\n" + json_message + "\n"
 
 
-puts "\nLet's delegate the message formatting to the `formatMessage` hook..."
+  puts "\nLet's delegate the message formatting to the `formatMessage` hook..."
 
-hook_request = { hook: {
-                   name: 'formatMessage',
-                   args: message
+  hook_request = { hook: {
+                     name: 'formatMessage',
+                     args: message
+                   }
                  }
-               }
-json_hook_request = MultiJson.dump(hook_request)
+  json_hook_request = MultiJson.dump(hook_request)
 
 
-# connect to the main_to_worker named pipe
-output = open("main_to_worker", "w+") # the w+ means we don't block
-# write to the named pipe
-output.puts json_hook_request
-output.flush
+  # connect to the main_to_worker named pipe
+  output = open(main_to_worker, "w+") # the w+ means we don't block
+  # write to the named pipe
+  output.puts json_hook_request
+  output.flush
 
-# ... the worker should be processing the hook
+  # ... the worker should be processing the hook
 
-# read from the worker_to_main named pipe
-input = open("worker_to_main", "r+") # the r+ means we don't block
+  # read from the worker_to_main named pipe
+  input = open(worker_to_main, "r+") # the r+ means we don't block
 
-# if the pipe is empty, `input.gets` will block,
-# that's to say will wait for the hook to send a response
-json_hook_response = input.gets
-hook_response = MultiJson.load(json_hook_response)
+  # if the pipe is empty, `input.gets` will block,
+  # that's to say will wait for the hook to send a response
+  json_hook_response = input.gets
+  hook_response = MultiJson.load(json_hook_response)
 
-if hook_response['exitStatus'].to_i == 0
-  puts 'Hook exited successfully!'
-  puts hook_response['payload']
-else
-  puts 'Hook failed.'
+  if hook_response['exitStatus'].to_i == 0
+    puts 'Hook exited successfully!'
+    puts hook_response['payload']
+  else
+    puts 'Hook failed.'
+  end
+end
+
+2.times do
+  delegate_hook_to_worker
 end


### PR DESCRIPTION
**As a** developer 
**In order to** be able to handle multiple hooks with a single worker 
**I want** it to continuously read from a _named pipe_ as long as the main program can have hooks to perform 
**And** I want that worker to exit when the main program exits!
